### PR TITLE
Update npm dependencies, add axios-retry package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@google-cloud/vertexai": "^1.2.0",
 				"@libsql/client": "^0.6.2",
 				"axios": "^1.7.2",
+				"axios-retry": "^4.4.0",
 				"better-sqlite3": "^11.0.0",
 				"date-fns": "^3.6.0",
 				"dotenv": "^16.4.5",
@@ -1116,6 +1117,17 @@
 				"proxy-from-env": "^1.1.0"
 			}
 		},
+		"node_modules/axios-retry": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.4.0.tgz",
+			"integrity": "sha512-yewTKjzl6jSgc+2M7FCJ3LxRGgL1iiXHcj+E6h6xie6H1mTHr7yqaUroWIvVXG1UKSPwGDXxV05YxtGvrD6Paw==",
+			"dependencies": {
+				"is-retry-allowed": "^2.2.0"
+			},
+			"peerDependencies": {
+				"axios": "0.x || 1.x"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2072,6 +2084,17 @@
 			"integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
 			"optional": true,
 			"peer": true
+		},
+		"node_modules/is-retry-allowed": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+			"integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
 		"@google-cloud/vertexai": "^1.2.0",
 		"@libsql/client": "^0.6.2",
 		"axios": "^1.7.2",
+		"axios-retry": "^4.4.0",
 		"better-sqlite3": "^11.0.0",
 		"date-fns": "^3.6.0",
 		"dotenv": "^16.4.5",


### PR DESCRIPTION
This pull request updates the npm dependencies and adds the axios-retry package. The axios-retry package is used to implement retry logic for API requests in the code. This ensures that if a request fails due to rate limiting (status code 429), it will be retried up to 5 times with an exponential backoff delay. This improves the reliability and resilience of the application when making API calls.