### PR TITLE
Remove image links from article markdown

### DIFF
--- a/src/fill_summary.ts
+++ b/src/fill_summary.ts
@@ -121,12 +121,14 @@ function generatePrompt(article: {
   ai_summary: string | null;
   time_added: Date | null;
 }): string {
+  // remove image links
+  const sanitized = article.markdown?.replace(/!\[.*?\]\((.*?)\)/g, "");
   return `
   Title: ${article.title}
   URL: ${article.url}
   Description: ${article.excerpt}
   <article_body>
-  ${article.markdown?.substring(0, 4000) ?? "empty result"}
+  ${sanitized?.substring(0, 8000) ?? "empty result"}
   </article_body>
 
   ---


### PR DESCRIPTION
This pull request removes image links from the article markdown. It sanitizes the markdown by removing any occurrences of `![...](...)`. This change ensures that the article content is free from image links, improving readability and reducing clutter.